### PR TITLE
merge release/20250528 into main

### DIFF
--- a/src/app/api/services/db/chatterpay-db-service.ts
+++ b/src/app/api/services/db/chatterpay-db-service.ts
@@ -530,6 +530,7 @@ export async function getUserTransactions(wallet: string): Promise<ITransaction[
           },
           token: 1,
           amount: 1,
+          fee: 1,
           type: 1,
           status: 1,
           trx_hash: 1

--- a/src/sections/account/change-email.tsx
+++ b/src/sections/account/change-email.tsx
@@ -40,7 +40,6 @@ export default function ChangeEmail() {
   const { counting, countdown, startCountdown } = useCountdownSeconds(60)
 
   const ChangeEmailSchema = Yup.object().shape({
-    oldEmail: Yup.string().email(t('common.must-be-valid-email')).required(t('common.required')),
     newEmail: Yup.string().email(t('common.must-be-valid-email')).required(t('common.required')),
     confirmEmail: Yup.string()
       .oneOf([Yup.ref('newEmail')], t('common.emails-must-match'))

--- a/src/sections/banking/banking-recent-transitions.tsx
+++ b/src/sections/banking/banking-recent-transitions.tsx
@@ -1,3 +1,5 @@
+import { useMemo } from 'react'
+
 import Box from '@mui/material/Box'
 import Table from '@mui/material/Table'
 import Avatar from '@mui/material/Avatar'
@@ -20,6 +22,7 @@ import { useResponsive } from 'src/hooks/use-responsive'
 
 import { fNumber } from 'src/utils/format-number'
 import { fDate, fTime } from 'src/utils/format-time'
+import { maskAddress } from 'src/utils/format-address'
 
 import { useTranslate } from 'src/locales'
 import { EXPLORER_L2_URL } from 'src/config-global'
@@ -176,18 +179,24 @@ function getContactData(
   userWallet: string,
   data: ITransaction,
   mdUp: boolean
-): { contact: string; phone: string } {
+): { contact: string; phone: string; walletTo: string; calculatedAmount: string } {
   let contact: string = ''
   let phone: string = ''
+  let walletTo: string = ''
+  let calculatedAmount: string = ''
 
   const trxReceive: boolean = userWallet === data.wallet_to
 
   if (data.type.toLowerCase() === 'swap') {
     contact = (trxReceive ? data.contact_to_name : data.contact_from_name) || ''
     phone = (trxReceive ? data.contact_to_phone : data.contact_from_phone) || ''
+    calculatedAmount = fNumber(data.amount)
+    walletTo = data.wallet_to || ''
   } else {
     contact = (trxReceive ? data.contact_from_name : data.contact_to_name) || ''
     phone = (trxReceive ? data.contact_from_phone : data.contact_to_phone) || ''
+    calculatedAmount = fNumber(data.amount - (trxReceive ? data.fee || 0 : 0))
+    walletTo = data.wallet_to || ''
   }
 
   // hide contact name in mobile
@@ -195,7 +204,7 @@ function getContactData(
     contact = ''
   }
 
-  return { contact, phone }
+  return { contact, phone, walletTo, calculatedAmount }
 }
 
 function BankingRecentTransitionsRow({ userWallet, row, mdUp }: BankingRecentTransitionsRowProps) {
@@ -203,7 +212,7 @@ function BankingRecentTransitionsRow({ userWallet, row, mdUp }: BankingRecentTra
   const { t } = useTranslate()
   const lightMode = theme.palette.mode === 'light'
   const trxReceive: boolean = userWallet === row.wallet_to
-  const { contact, phone } = getContactData(userWallet, row, mdUp)
+  const { contact, phone, walletTo, calculatedAmount } = getContactData(userWallet, row, mdUp)
   const message: string = `${
     trxReceive ? t('transactions.receive-from') : t('transactions.sent-to')
   } ${contact}`
@@ -225,6 +234,14 @@ function BankingRecentTransitionsRow({ userWallet, row, mdUp }: BankingRecentTra
     popover.onClose()
     console.info('SHARE', row.id)
   }
+
+  const getToIdentifier = useMemo(() => {
+    if (phone.length > 0) {
+      return phone
+    }
+
+    return maskAddress(walletTo)
+  }, [phone, walletTo])
 
   const renderAvatar = (
     <Box sx={{ position: 'relative', mr: 2 }}>
@@ -269,11 +286,11 @@ function BankingRecentTransitionsRow({ userWallet, row, mdUp }: BankingRecentTra
             <Iconify icon='eva:external-link-outline' />
           </IconButton>
         </Link>
-        <ListItemText primary={message} secondary={phone} />
+        <ListItemText primary={message} secondary={getToIdentifier} />
       </TableCell>
 
       <TableCell>
-        {fNumber(row.amount)} {row.token}
+        {calculatedAmount} {row.token}
       </TableCell>
 
       <TableCell>{row.type}</TableCell>
@@ -344,7 +361,7 @@ function BankingRecentTransitionsRow({ userWallet, row, mdUp }: BankingRecentTra
           primary={message}
           secondary={
             <>
-              {phone}
+              {getToIdentifier}
               <Box component='span' sx={{ display: 'block', mt: 0.5 }}>
                 {`${fDate(new Date(row.date))} ${fTime(new Date(row.date))}`}
               </Box>
@@ -360,7 +377,7 @@ function BankingRecentTransitionsRow({ userWallet, row, mdUp }: BankingRecentTra
 
       <TableCell sx={{ width: '35%', textAlign: 'right' }}>
         <ListItemText
-          primary={`${fNumber(row.amount)} ${row.token}`}
+          primary={`${calculatedAmount} ${row.token}`}
           secondary={
             <Label
               variant={lightMode ? 'soft' : 'filled'}

--- a/src/sections/banking/view/transfer-all-view.tsx
+++ b/src/sections/banking/view/transfer-all-view.tsx
@@ -20,7 +20,7 @@ export default function TransferAllView() {
   return (
     <Container maxWidth={settings.themeStretch ? false : 'lg'}>
       <CustomBreadcrumbs
-        heading={t('menu.email')}
+        heading={t('menu.transfer-all')}
         links={[
           { name: t('menu._dashboard'), href: paths.dashboard.root },
           { name: t('menu.transfer-all') }

--- a/src/types/wallet.ts
+++ b/src/types/wallet.ts
@@ -67,6 +67,7 @@ export type ITransaction = {
   contact_to_avatar_url: string | null
   token: string
   amount: number
+  fee: number
   type: string
   status: string
 }

--- a/src/utils/format-address.ts
+++ b/src/utils/format-address.ts
@@ -1,0 +1,8 @@
+/**
+ * Mask the address with the first 5 and last 4 characters
+ * @param address
+ * @returns
+ */
+export function maskAddress(address: string): string {
+  return `${address.slice(0, 4)}****${address.slice(-4)}`
+}

--- a/src/utils/format-number.ts
+++ b/src/utils/format-number.ts
@@ -46,10 +46,11 @@ export function fNumber(inputValue: InputValue) {
   if (!inputValue) return ''
 
   const number = Number(inputValue)
+  const isSmall = Math.abs(number) < 0.01 && number !== 0
 
   const fm = new Intl.NumberFormat(code, {
-    minimumFractionDigits: 0,
-    maximumFractionDigits: 2
+    minimumFractionDigits: isSmall ? 4 : 0,
+    maximumFractionDigits: isSmall ? 8 : 2
   }).format(number)
 
   return fm


### PR DESCRIPTION
### Changes

- Corrected withdraw-all Title.
- The transaction list now displayed the amount minus the fee, only for transfers.
- Allowed email change when old email was empty.
- Displayed transfers to external wallets and masked the addresses in the transaction list.
- It corrected the display of very small token amounts in the transaction list by allowing greater precision in number formatting. This ensures accurate representation of low-value transfers and improves the overall user experience when interacting with highly divisible 

### Related to:

- #209
- #211
- #216
- #221