### PR TITLE
merge fix/225-i18-hydration-error into develop

### DIFF
--- a/src/hooks/use-translation-ready.ts
+++ b/src/hooks/use-translation-ready.ts
@@ -1,0 +1,25 @@
+'use client'
+
+import { useState, useEffect } from 'react'
+
+import i18n from 'src/locales/i18n'
+
+// ----------------------------------------------------------------------
+
+/**
+ * Custom hook to delay rendering until i18n is fully initialized.
+ * Helps avoid hydration issues by ensuring translations are ready before rendering.
+ *
+ * Note: This hook listens to the i18n 'initialized' event and updates state accordingly.
+ */
+export function useTranslationReady() {
+  const [ready, setReady] = useState(i18n.isInitialized)
+
+  useEffect(() => {
+    if (!i18n.isInitialized) {
+      i18n.on('initialized', () => setReady(true))
+    }
+  }, [])
+
+  return ready
+}

--- a/src/layouts/main/index.tsx
+++ b/src/layouts/main/index.tsx
@@ -1,6 +1,12 @@
+'use client'
+
+import { useState, useEffect } from 'react'
+
 import Box from '@mui/material/Box'
 
 import { usePathname } from 'src/routes/hooks'
+
+import i18n from 'src/locales/i18n'
 
 import Footer from './footer'
 import Header from './header'
@@ -13,8 +19,16 @@ type Props = {
 
 export default function MainLayout({ children }: Props) {
   const pathname = usePathname()
-
   const homePage = pathname === '/'
+  const [ready, setReady] = useState(i18n.isInitialized)
+
+  useEffect(() => {
+    if (!i18n.isInitialized) {
+      i18n.on('initialized', () => setReady(true))
+    }
+  }, [])
+
+  if (!ready) return null
 
   return (
     <Box sx={{ display: 'flex', flexDirection: 'column', height: 1 }}>

--- a/src/locales/i18n.ts
+++ b/src/locales/i18n.ts
@@ -31,6 +31,9 @@ i18n
     defaultNS: 'translations',
     interpolation: {
       escapeValue: false
+    },
+    react: {
+      useSuspense: true
     }
   })
 


### PR DESCRIPTION
### Changes:

- Three key changes were implemented to prevent hydration errors and ensure consistent translation loading on the frontend. First, Suspense support was enabled in i18next, allowing React to delay rendering until translations are ready. Then, a new hook useTranslationReady was introduced to explicitly check if i18n has been initialized. Finally, the MainLayout component was updated to conditionally render only after i18n is ready, preventing client-server mismatches during the initial render.

### Closes:

- #225