### PR TITLE
merge feature/235-unnecessary-echo-statements into develop

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -132,7 +132,6 @@ steps:
   - name: 'bash'
     script: |
       #!/usr/bin/env bash
-      echo 'BACKEND_API_TOKEN en cloudbuild.yaml 1: $BACKEND_API_TOKEN_SECRET'
     secretEnv: [
       'BACKEND_API_TOKEN_SECRET'
     ]


### PR DESCRIPTION
### Changes

- Removeed redundant `echo` statements from `cloudBuild.yaml` to reduce noise in build logs. These messages were not essential for debugging or diagnostics and have been cleaned up to improve log clarity.


### Closes:

- #235
