### PR TITLE
merge feature/274-update-security-headers into develop

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -110,8 +110,8 @@ module.exports = {
           }
         ]
       },
-      {
-      source: '/:path*',
+      {  
+        source: '/:path*',
         headers: [
           {
             key: 'Content-Security-Policy',
@@ -138,7 +138,12 @@ module.exports = {
               img-src 'self' data: https:;
               style-src 'self' 'unsafe-inline';
               frame-src 'self' https://www.google.com https://www.youtube.com;
+              frame-ancestors 'self';
             `.replace(/\s+/g, ' ').trim()
+          },
+          {
+            key: 'X-Frame-Options',
+            value: 'DENY'
           }
         ]
       }


### PR DESCRIPTION
### Changes
- Security headers were updated to strengthen the application’s protection against clickjacking and related UI redress risks. The implementation added `Content-Security-Policy` with `frame-ancestors 'self';` and the legacy fallback `X-Frame-Options: DENY`, ensuring the site can no longer be embedded within untrusted frames. This improvement enhanced overall platform security and aligned the deployment with modern web security standards.


### Related To:
- #274 