### PR TITLE
merge feature/network-changes into dev

### DIFF
--- a/src/app/api/hooks/api-resolver.ts
+++ b/src/app/api/hooks/api-resolver.ts
@@ -94,7 +94,9 @@ export const endpoints = {
     refresh: () => getFullUIEndpoint('auth/refresh')
   },
   nft: {
-    id: (id: string) => getFullUIEndpoint(`nft/${id}`)
+    // chainId disambiguates token ids, which repeat across networks.
+    id: (id: string, chainId?: number) =>
+      getFullUIEndpoint(`nft/${id}${chainId ? `?chainId=${chainId}` : ''}`)
   },
   tokens: getFullUIEndpoint('tokens'),
   proxy: {

--- a/src/app/api/hooks/api-resolver.ts
+++ b/src/app/api/hooks/api-resolver.ts
@@ -140,10 +140,16 @@ export const endpoints = {
     },
     wallet: {
       balance: (id: string) => getFullUIEndpoint(`wallet/${id}/balance`),
-      transactions: (id: string, params?: { limit?: number; since?: string | number }) => {
+      transactions: (
+        id: string,
+        // `allChains` aggregates the history of every wallet of the owner, so the
+        // user still sees what they did on networks the app no longer operates on.
+        params?: { limit?: number; since?: string | number; allChains?: boolean }
+      ) => {
         const search = new URLSearchParams()
         if (params?.limit != null) search.append('limit', String(params.limit))
         if (params?.since != null) search.append('since', String(params.since))
+        if (params?.allChains) search.append('scope', 'user')
         const qs = search.toString()
         return getFullUIEndpoint(`wallet/${id}/transactions${qs ? `?${qs}` : ''}`)
       },
@@ -152,7 +158,8 @@ export const endpoints = {
           `wallet/${id}/notifications?lazy=true&pageIndex=${pageIndex}&pageSize=${pageSize}`
         ),
       nfts: {
-        root: (id: string) => getFullUIEndpoint(`wallet/${id}/nfts`),
+        root: (id: string, params?: { allChains?: boolean }) =>
+          getFullUIEndpoint(`wallet/${id}/nfts${params?.allChains ? '?scope=user' : ''}`),
         id: (walletId: string, nftId: string) =>
           getFullUIEndpoint(`wallet/${walletId}/nfts/${nftId}`)
       },

--- a/src/app/api/hooks/use-nft.ts
+++ b/src/app/api/hooks/use-nft.ts
@@ -4,6 +4,6 @@ import { useGetCommon } from './common'
 
 // ----------------------------------------------------------------------
 
-export function useGetNftById(nftId: string) {
-  return useGetCommon(endpoints.nft.id(nftId))
+export function useGetNftById(nftId: string, chainId?: number) {
+  return useGetCommon(endpoints.nft.id(nftId, chainId))
 }

--- a/src/app/api/hooks/use-wallet.ts
+++ b/src/app/api/hooks/use-wallet.ts
@@ -41,12 +41,15 @@ export function useGetWalletTransactions(walletId: string) {
 const HEAD_LIMIT = 50
 const TX_CACHE_MAX = 200
 
-const txCacheKey = (walletId: string) => `cp:txs:${walletId}`
+// The cache key carries the scope: the all-chains timeline is a superset of the
+// single-wallet one, so mixing both under the same key would leak rows between them.
+const txCacheKey = (walletId: string, allChains?: boolean) =>
+  `cp:txs:${walletId}${allChains ? ':all' : ''}`
 
-function readTxCache(walletId: string): ITransaction[] {
+function readTxCache(walletId: string, allChains?: boolean): ITransaction[] {
   if (typeof window === 'undefined' || !walletId) return []
   try {
-    const raw = window.localStorage.getItem(txCacheKey(walletId))
+    const raw = window.localStorage.getItem(txCacheKey(walletId, allChains))
     if (!raw) return []
     const parsed = JSON.parse(raw)
     return Array.isArray(parsed) ? parsed : []
@@ -55,10 +58,13 @@ function readTxCache(walletId: string): ITransaction[] {
   }
 }
 
-function writeTxCache(walletId: string, txs: ITransaction[]) {
+function writeTxCache(walletId: string, txs: ITransaction[], allChains?: boolean) {
   if (typeof window === 'undefined' || !walletId) return
   try {
-    window.localStorage.setItem(txCacheKey(walletId), JSON.stringify(txs.slice(0, TX_CACHE_MAX)))
+    window.localStorage.setItem(
+      txCacheKey(walletId, allChains),
+      JSON.stringify(txs.slice(0, TX_CACHE_MAX))
+    )
   } catch {
     // ignore quota / serialization errors — cache is best-effort
   }
@@ -80,14 +86,16 @@ function mergeTransactions(cached: ITransaction[], fresh: ITransaction[]): ITran
   return Array.from(map.values()).sort((a, b) => txTime(b) - txTime(a))
 }
 
-export function useGetWalletTransactionsCached(walletId: string) {
+export function useGetWalletTransactionsCached(walletId: string, opts?: { allChains?: boolean }) {
+  const allChains = !!opts?.allChains
+
   // Synchronous read so the very first render already shows cached history.
-  const initialCache = useMemo(() => readTxCache(walletId), [walletId])
+  const initialCache = useMemo(() => readTxCache(walletId, allChains), [walletId, allChains])
 
   const { data, error, isLoading, isValidating, mutate } = useSWR(
     walletId
       ? [
-          endpoints.dashboard.wallet.transactions(walletId, { limit: HEAD_LIMIT }),
+          endpoints.dashboard.wallet.transactions(walletId, { limit: HEAD_LIMIT, allChains }),
           { headers: getAuthorizationHeader() }
         ]
       : null,
@@ -108,8 +116,8 @@ export function useGetWalletTransactionsCached(walletId: string) {
   const merged = useMemo(() => mergeTransactions(initialCache, fresh), [initialCache, fresh])
 
   useEffect(() => {
-    if (walletId && fresh.length) writeTxCache(walletId, merged)
-  }, [walletId, merged, fresh.length])
+    if (walletId && fresh.length) writeTxCache(walletId, merged, allChains)
+  }, [walletId, merged, fresh.length, allChains])
 
   return useMemo(
     () => ({
@@ -124,9 +132,16 @@ export function useGetWalletTransactionsCached(walletId: string) {
   )
 }
 
-export function useGetWalletNfts(walletId?: string) {
+/**
+ * NFTs of a wallet, or of every wallet of its owner when `allChains` is set —
+ * the latter is what lets the gallery show mints from networks the app no
+ * longer operates on.
+ */
+export function useGetWalletNfts(walletId?: string, opts?: { allChains?: boolean }) {
   return useGetCommon(
-    walletId ? endpoints.dashboard.wallet.nfts.root(walletId) : null,
+    walletId
+      ? endpoints.dashboard.wallet.nfts.root(walletId, { allChains: opts?.allChains })
+      : null,
     walletId ? { headers: getAuthorizationHeader() } : {}
   )
 }

--- a/src/app/api/services/db/chatterpay-db-service.ts
+++ b/src/app/api/services/db/chatterpay-db-service.ts
@@ -1,11 +1,11 @@
 import type { ObjectId, Collection } from 'mongodb'
 
-import { DB_BOT_NAME, DB_CHATTERPAY_NAME } from 'src/config-global'
+import { DB_BOT_NAME, DEFAULT_CHAIN_ID, DB_CHATTERPAY_NAME } from 'src/config-global'
 
 import type { JwtPayload } from 'src/types/jwt'
 import type { LastUserConversation } from 'src/types/chat'
 import type { INFT, IToken, ITransaction } from 'src/types/wallet'
-import type { IAccount, UserSession } from 'src/types/account'
+import type { IAccount, UserSession, IAccountWallet } from 'src/types/account'
 
 import { getClientPromise } from './_connections/mongo-connection'
 import { getClientPromiseBot } from './_connections/mongo-bot-onnection'
@@ -72,6 +72,56 @@ interface UserConversation {
 
 // ----------------------------------------------------------------------
 
+/**
+ * Wallets a user owns, normalized and ordered with the active chain first.
+ * A user accumulates one wallet per network they have operated on; the app
+ * operates on the active chain but still shows the others as history.
+ * @param {IAccountDB['wallets']} wallets - Raw wallets array from Mongo.
+ * @returns {IAccountWallet[]} Normalized wallets, active chain first.
+ */
+function normalizeWallets(wallets: IAccountDB['wallets']): IAccountWallet[] {
+  if (!Array.isArray(wallets)) return []
+
+  return wallets
+    .filter((w) => !!w?.wallet_proxy)
+    .map((w) => ({
+      wallet_proxy: w.wallet_proxy,
+      wallet_eoa: w.wallet_eoa,
+      chain_id: w.chain_id,
+      status: w.status
+    }))
+    .sort((a, b) => {
+      if (a.chain_id === b.chain_id) return 0
+      if (a.chain_id === DEFAULT_CHAIN_ID) return -1
+      if (b.chain_id === DEFAULT_CHAIN_ID) return 1
+      return 0
+    })
+}
+
+/**
+ * Splits a user document into the active-chain wallet plus the full wallet list.
+ * Picking by chain matters once a user has wallets on more than one network:
+ * `wallets[0]` is whichever chain they used first, not the one the app operates on.
+ * @param {IAccountDB['wallets']} wallets - Raw wallets array from Mongo.
+ * @returns {{ wallet: string; walletEOA: string; wallets: IAccountWallet[] }} Active wallet and list.
+ */
+function resolveUserWallets(wallets: IAccountDB['wallets']): {
+  wallet: string
+  walletEOA: string
+  wallets: IAccountWallet[]
+} {
+  const all = normalizeWallets(wallets)
+  // `all` is sorted active-chain-first, so the head is the active wallet when it
+  // exists; otherwise fall back to the first one so legacy users keep working.
+  const active = all.find((w) => w.chain_id === DEFAULT_CHAIN_ID) ?? all[0]
+
+  return {
+    wallet: active?.wallet_proxy || '',
+    walletEOA: active?.wallet_eoa || '',
+    wallets: all
+  }
+}
+
 export async function getUserByPhone(phone: string): Promise<IAccount | undefined> {
   const client = await getClientPromise()
   const db = client.db(DB_CHATTERPAY_NAME)
@@ -94,15 +144,14 @@ export async function getUserByPhone(phone: string): Promise<IAccount | undefine
 
   const { _id, wallets, ...rest } = data
 
-  // Assuming that wallets is an array and we're only taking the first wallet
-  const wallet = wallets && wallets.length > 0 ? wallets[0].wallet_proxy : ''
-  const walletEOA = wallets && wallets.length > 0 ? wallets[0].wallet_eoa : ''
+  const { wallet, walletEOA, wallets: userWallets } = resolveUserWallets(wallets)
 
   // Transform the user object to match the old model
   const user: IAccount = {
     id: getFormattedId(_id),
     wallet,
     walletEOA,
+    wallets: userWallets,
     ...rest
   }
   return user
@@ -123,15 +172,14 @@ export async function getUserById(id: string): Promise<IAccount | undefined> {
   // Destructure _id and other properties from the user data
   const { _id, wallets, ...rest } = data
 
-  // If wallets exist, extract the first wallet's wallet_proxy and wallet_eoa
-  const wallet = wallets && wallets.length > 0 ? wallets[0].wallet_proxy : ''
-  const walletEOA = wallets && wallets.length > 0 ? wallets[0].wallet_eoa : ''
+  const { wallet, walletEOA, wallets: userWallets } = resolveUserWallets(wallets)
 
   // Transform the user data to match the IAccount model
   const user: IAccount = {
     id: getFormattedId(_id), // Add the formatted user ID
-    wallet, // Add wallet
-    walletEOA, // Add walletEOA
+    wallet, // Active-chain proxy wallet
+    walletEOA, // Active-chain EOA
+    wallets: userWallets, // Every wallet, one per chain
     ...rest
   }
 
@@ -155,6 +203,25 @@ export async function getUserIdByWallet(userWallet: string): Promise<string | un
   }
 
   return getFormattedId(data._id)
+}
+
+/**
+ * Every proxy wallet a user owns, one per chain. Used by the read-only views
+ * that aggregate history across networks (NFTs, transactions).
+ * @param {string} userId - ChatterPay user id.
+ * @returns {Promise<string[]>} Proxy wallet addresses, active chain first.
+ */
+export async function getUserWalletAddresses(userId: string): Promise<string[]> {
+  const client = await getClientPromise()
+  const db = client.db(DB_CHATTERPAY_NAME)
+
+  const data: IAccountDB | null = await db
+    .collection(SCHEMA_USERS)
+    .findOne({ _id: getObjectId(userId) })
+
+  if (!data) return []
+
+  return normalizeWallets(data.wallets).map((w) => w.wallet_proxy)
 }
 
 export async function updateUserCode(userId: string, code: number | undefined): Promise<boolean> {
@@ -401,16 +468,21 @@ export async function updateUserSessionStatus(
   return result
 }
 
-export async function getWalletNfts(wallet: string): Promise<INFT[] | undefined> {
+export async function getWalletNfts(wallet: string | string[]): Promise<INFT[] | undefined> {
   const client = await getClientPromise()
   const db = client.db(DB_CHATTERPAY_NAME)
+
+  // A single wallet belongs to a single chain, so passing every wallet of the
+  // user is what returns their NFTs across all the networks they operated on.
+  const wallets = Array.isArray(wallet) ? wallet : [wallet]
+  if (wallets.length === 0) return undefined
 
   const cursor: INFTDB[] | null = await db
     .collection(SCHEMA_NFTS)
     .aggregate([
       {
         $match: {
-          wallet
+          wallet: { $in: wallets }
         }
       },
       {
@@ -428,7 +500,8 @@ export async function getWalletNfts(wallet: string): Promise<INFT[] | undefined>
           copy_order: 1,
           copy_of_original: 1,
           copy_order_original: 1,
-          minted_contract_address: 1
+          minted_contract_address: 1,
+          chain_id: 1
         }
       },
       {
@@ -487,13 +560,27 @@ export async function getWalletNfts(wallet: string): Promise<INFT[] | undefined>
   return nfts
 }
 
-export async function getNftById(nftId: string): Promise<INFT | undefined> {
+/**
+ * Finds an NFT by its on-chain token id.
+ *
+ * Token ids restart from zero on every network, so the id on its own does not
+ * identify an NFT: the same id exists on more than one chain. The active
+ * network wins, and only if the id is unknown there do we fall back to the most
+ * recent match on any other network, so links shared before a network switch
+ * keep resolving to the NFT they were created for.
+ */
+export async function getNftById(nftId: string, chainId?: number): Promise<INFT | undefined> {
   const client = await getClientPromise()
   const db = client.db(DB_CHATTERPAY_NAME)
+  const collection = db.collection(SCHEMA_NFTS)
 
-  const nft: INFT | null = await db.collection(SCHEMA_NFTS).findOne({
-    id: nftId
+  const nftOnChain: INFT | null = await collection.findOne({
+    id: nftId,
+    chain_id: chainId ?? DEFAULT_CHAIN_ID
   })
+
+  const nft: INFT | null =
+    nftOnChain ?? (await collection.findOne({ id: nftId }, { sort: { timestamp: -1 } }))
 
   if (!nft) {
     return undefined
@@ -506,9 +593,11 @@ export async function getWalletNft(wallet: string, nftId: string): Promise<INFT 
   const client = await getClientPromise()
   const db = client.db(DB_CHATTERPAY_NAME)
 
+  // Token ids are stored as strings; a wallet belongs to a single chain, so the
+  // wallet is what scopes the lookup to one network.
   const nft: INFTDB | null = await db.collection(SCHEMA_NFTS).findOne({
     wallet,
-    id: Number(nftId)
+    id: String(nftId)
   })
 
   if (!nft) {
@@ -536,15 +625,19 @@ export async function getWalletNft(wallet: string, nftId: string): Promise<INFT 
 }
 
 export async function getUserTransactions(
-  wallet: string,
+  wallet: string | string[],
   opts?: { limit?: number; since?: string | number | Date }
 ): Promise<ITransaction[] | undefined> {
   const client = await getClientPromise()
   const db = client.db(DB_CHATTERPAY_NAME)
 
-  // Base ownership filter
+  // Base ownership filter. Passing every wallet of the user aggregates the
+  // history of all the networks they operated on into a single timeline.
+  const wallets = Array.isArray(wallet) ? wallet : [wallet]
+  if (wallets.length === 0) return undefined
+
   const match: Record<string, any> = {
-    $or: [{ wallet_from: wallet }, { wallet_to: wallet }]
+    $or: [{ wallet_from: { $in: wallets } }, { wallet_to: { $in: wallets } }]
   }
 
   // Incremental fetch: only return records newer than `since`. The bot writes `date`

--- a/src/app/api/services/db/chatterpay-db-service.ts
+++ b/src/app/api/services/db/chatterpay-db-service.ts
@@ -518,11 +518,23 @@ export async function getWalletNfts(wallet: string | string[]): Promise<INFT[] |
       },
       {
         // Realizar un lookup para obtener el total_of_this
-        // del registro original relacionado
+        // del registro original relacionado. El id de un token solo es único
+        // dentro de una red, así que el original tiene que buscarse en la misma
+        // chain: si no, una copia puede tomar el total de un NFT ajeno que
+        // comparte su id en otra red.
         $lookup: {
           from: SCHEMA_NFTS,
-          localField: 'copy_of_original',
-          foreignField: 'id',
+          let: { originalId: '$copy_of_original', chainId: '$chain_id' },
+          pipeline: [
+            {
+              $match: {
+                $expr: {
+                  $and: [{ $eq: ['$id', '$$originalId'] }, { $eq: ['$chain_id', '$$chainId'] }]
+                }
+              }
+            },
+            { $project: { total_of_this: 1 } }
+          ],
           as: 'original_nft'
         }
       },

--- a/src/app/api/v1/auth/login/route.ts
+++ b/src/app/api/v1/auth/login/route.ts
@@ -91,7 +91,9 @@ export async function POST(req: NextRequest) {
       phoneNumber: user.phone_number || ''
     }
     const data: Record<string, any> = {
-      user: dataUser,
+      // The wallet list is display-only and would bloat every request if signed
+      // into the token, so it travels in the response body only.
+      user: { ...dataUser, wallets: user.wallets || [] },
       sessionId: userSession.id,
       jwtToken: generateJwtToken(dataUser, userSession)
     }

--- a/src/app/api/v1/auth/me/route.ts
+++ b/src/app/api/v1/auth/me/route.ts
@@ -14,6 +14,7 @@ const defaultUser: jwtPayloadUser = {
   displayName: '',
   wallet: '',
   walletEOA: '',
+  wallets: [],
   email: '',
   photoURL: '',
   phoneNumber: ''
@@ -38,6 +39,7 @@ export async function GET() {
               displayName: user.name,
               wallet: user.wallet,
               walletEOA: user.walletEOA || '',
+              wallets: user.wallets || [],
               email: user.email || '',
               photoURL: user.photo,
               phoneNumber: user.phone_number

--- a/src/app/api/v1/nft/[id]/route.ts
+++ b/src/app/api/v1/nft/[id]/route.ts
@@ -32,7 +32,13 @@ export async function GET(request: Request, { params }: { params: IParams }) {
   }
 
   try {
-    const nft: INFT | undefined = await getNftById(params.id)
+    // Token ids repeat across networks, so a shared link may carry the network
+    // it was minted on. Without it, the active network is assumed.
+    const chainIdParam = new URL(request.url).searchParams.get('chainId')
+    const chainId =
+      chainIdParam && !Number.isNaN(Number(chainIdParam)) ? Number(chainIdParam) : undefined
+
+    const nft: INFT | undefined = await getNftById(params.id, chainId)
 
     if (nft) {
       return NextResponse.json(nft)

--- a/src/app/api/v1/user/[id]/route.ts
+++ b/src/app/api/v1/user/[id]/route.ts
@@ -48,6 +48,7 @@ export async function GET(req: NextRequest, { params }: { params: IParams }) {
       displayName: user.name,
       wallet: user.wallet,
       walletEOA: user.walletEOA || '',
+      wallets: user.wallets || [],
       email: user.email || '',
       photoURL: user.photo,
       phoneNumber: user.phone_number

--- a/src/app/api/v1/wallet/[id]/nfts/route.ts
+++ b/src/app/api/v1/wallet/[id]/nfts/route.ts
@@ -1,6 +1,9 @@
 import { type NextRequest, NextResponse } from 'next/server'
 
-import { getWalletNfts } from 'src/app/api/services/db/chatterpay-db-service'
+import {
+  getWalletNfts,
+  getUserWalletAddresses
+} from 'src/app/api/services/db/chatterpay-db-service'
 import { validateRequestSecurity } from 'src/app/api/middleware/validators/base-security-validator'
 import { validateWalletCommonsInputs as validateWalletCommonInputs } from 'src/app/api/middleware/validators/wallet-common-inputs-validator'
 
@@ -22,7 +25,16 @@ export async function GET(req: NextRequest, { params }: { params: IParams }) {
   if (securityCheckResult instanceof NextResponse) return securityCheckResult
 
   try {
-    const nfts = (await getWalletNfts(walletId)) || {}
+    // `scope=user` widens the query to every wallet of the owner, so the gallery
+    // can also show NFTs minted on networks the app no longer operates on.
+    const scope = new URL(req.url).searchParams.get('scope')
+    let wallets: string | string[] = walletId
+    if (scope === 'user') {
+      const userWallets = await getUserWalletAddresses(userId)
+      if (userWallets.length > 0) wallets = userWallets
+    }
+
+    const nfts = (await getWalletNfts(wallets)) || {}
     return NextResponse.json(nfts)
   } catch (ex) {
     console.error(ex)

--- a/src/app/api/v1/wallet/[id]/transactions/route.ts
+++ b/src/app/api/v1/wallet/[id]/transactions/route.ts
@@ -1,6 +1,9 @@
 import { type NextRequest, NextResponse } from 'next/server'
 
-import { getUserTransactions } from 'src/app/api/services/db/chatterpay-db-service'
+import {
+  getUserTransactions,
+  getUserWalletAddresses
+} from 'src/app/api/services/db/chatterpay-db-service'
 import { validateRequestSecurity } from 'src/app/api/middleware/validators/base-security-validator'
 import { validateWalletCommonsInputs as validateWalletCommonInputs } from 'src/app/api/middleware/validators/wallet-common-inputs-validator'
 
@@ -31,8 +34,17 @@ export async function GET(req: NextRequest, { params }: { params: IParams }) {
     const limitParam = searchParams.get('limit')
     const sinceParam = searchParams.get('since')
     const limit = limitParam ? Number(limitParam) : undefined
+
+    // `scope=user` widens the query to every wallet of the owner, so the history
+    // aggregates the networks the user operated on instead of just the active one.
+    let wallets: string | string[] = walletId
+    if (searchParams.get('scope') === 'user') {
+      const userWallets = await getUserWalletAddresses(userId)
+      if (userWallets.length > 0) wallets = userWallets
+    }
+
     const data: ITransaction[] =
-      (await getUserTransactions(walletId, {
+      (await getUserTransactions(wallets, {
         limit: limit != null && Number.isFinite(limit) ? limit : undefined,
         since: sinceParam ?? undefined
       })) ?? []

--- a/src/app/nfts/mint/[id]/page.tsx
+++ b/src/app/nfts/mint/[id]/page.tsx
@@ -6,6 +6,15 @@ export const metadata = {
   title: 'NFT Mint'
 }
 
-export default function NftMintPage({ params }: { params: { id: string } }) {
-  return <NftMintView nftId={params.id} />
+export default function NftMintPage({
+  params,
+  searchParams
+}: {
+  params: { id: string }
+  searchParams?: { chainId?: string }
+}) {
+  // Token ids repeat across networks; a link may name the one it belongs to.
+  const chainId = Number(searchParams?.chainId) || undefined
+
+  return <NftMintView nftId={params.id} chainId={chainId} />
 }

--- a/src/app/nfts/share/[id]/page.tsx
+++ b/src/app/nfts/share/[id]/page.tsx
@@ -6,6 +6,15 @@ export const metadata = {
   title: 'NFT Share'
 }
 
-export default function NftMintPage({ params }: { params: { id: string } }) {
-  return <NftShareView nftId={params.id} />
+export default function NftMintPage({
+  params,
+  searchParams
+}: {
+  params: { id: string }
+  searchParams?: { chainId?: string }
+}) {
+  // Token ids repeat across networks; a link may name the one it belongs to.
+  const chainId = Number(searchParams?.chainId) || undefined
+
+  return <NftShareView nftId={params.id} chainId={chainId} />
 }

--- a/src/config-chains.ts
+++ b/src/config-chains.ts
@@ -1,0 +1,162 @@
+import {
+  NETWORK_NAME,
+  EXPLORER_L2_URL,
+  DEFAULT_CHAIN_ID,
+  EXPLORER_NFT_URL,
+  GCP_BUCKET_BASE_URL,
+  NFT_MARKETPLACE_URL
+} from './config-global'
+
+// ----------------------------------------------------------------------
+// Chain registry
+//
+// The app *operates* on a single chain at a time (the active one, configured
+// via NEXT_PUBLIC_DEFAULT_CHAIN_ID + the NEXT_PUBLIC_EXPLORER_* vars). But it
+// has to *display* data that belongs to other chains: a user keeps the wallet,
+// NFTs and transaction history of every network they ever operated on, and
+// those rows need their own explorer / marketplace links.
+//
+// A single active value per environment variable can't cover that, so the
+// per-chain, non-sensitive presentation config lives here, versioned with the
+// code and indexed by chain id. The active chain still reads its URLs from the
+// environment first, so a deployment can override them without a code change.
+// ----------------------------------------------------------------------
+
+export type ChainConfig = {
+  chainId: number
+  /** Human-readable network name shown in the UI. */
+  name: string
+  /** Block explorer base URL (no trailing slash). */
+  explorerUrl: string
+  /** Explorer used for NFT mint transactions — usually the same as `explorerUrl`. */
+  nftExplorerUrl: string
+  /** NFT marketplace collection base URL: `<url>/<contract>/<tokenId>`. */
+  nftMarketplaceUrl: string
+  /**
+   * Network icon, relative to GCP_BUCKET_BASE_URL. Empty when there is no
+   * artwork uploaded for the chain — callers fall back to a text avatar.
+   */
+  logo: string
+  testnet: boolean
+}
+
+const stripTrailingSlash = (url: string): string => url.replace(/\/+$/, '')
+
+export const SCROLL_CHAIN_ID = 534352
+export const SCROLL_SEPOLIA_CHAIN_ID = 534351
+export const ARBITRUM_CHAIN_ID = 42161
+export const ARBITRUM_SEPOLIA_CHAIN_ID = 421614
+/** Polymarket runs on Polygon mainnet, regardless of the active ChatterPay network. */
+export const POLYGON_CHAIN_ID = 137
+
+export const CHAINS: Record<number, ChainConfig> = {
+  [SCROLL_CHAIN_ID]: {
+    chainId: SCROLL_CHAIN_ID,
+    name: 'Scroll',
+    explorerUrl: 'https://scrollscan.com',
+    nftExplorerUrl: 'https://scrollscan.com',
+    nftMarketplaceUrl: 'https://opensea.io/assets/scroll',
+    logo: '',
+    testnet: false
+  },
+  [SCROLL_SEPOLIA_CHAIN_ID]: {
+    chainId: SCROLL_SEPOLIA_CHAIN_ID,
+    name: 'Scroll Sepolia',
+    explorerUrl: 'https://sepolia.scrollscan.com',
+    nftExplorerUrl: 'https://sepolia.scrollscan.com',
+    nftMarketplaceUrl: 'https://testnets.opensea.io/assets/scroll-sepolia',
+    logo: '',
+    testnet: true
+  },
+  [ARBITRUM_CHAIN_ID]: {
+    chainId: ARBITRUM_CHAIN_ID,
+    name: 'Arbitrum',
+    explorerUrl: 'https://arbiscan.io',
+    nftExplorerUrl: 'https://arbiscan.io',
+    nftMarketplaceUrl: 'https://opensea.io/assets/arbitrum',
+    logo: '',
+    testnet: false
+  },
+  [ARBITRUM_SEPOLIA_CHAIN_ID]: {
+    chainId: ARBITRUM_SEPOLIA_CHAIN_ID,
+    name: 'Arbitrum Sepolia',
+    explorerUrl: 'https://sepolia.arbiscan.io',
+    nftExplorerUrl: 'https://sepolia.arbiscan.io',
+    nftMarketplaceUrl: 'https://testnets.opensea.io/assets/arbitrum_sepolia',
+    logo: '',
+    testnet: true
+  },
+  [POLYGON_CHAIN_ID]: {
+    chainId: POLYGON_CHAIN_ID,
+    name: 'Polygon',
+    explorerUrl: 'https://polygonscan.com',
+    nftExplorerUrl: 'https://polygonscan.com',
+    nftMarketplaceUrl: 'https://opensea.io/assets/matic',
+    logo: '',
+    testnet: false
+  }
+}
+
+// ----------------------------------------------------------------------
+
+const isActiveChain = (chainId?: number): boolean => chainId == null || chainId === DEFAULT_CHAIN_ID
+
+/**
+ * Registry entry for a chain id, or `undefined` when the chain is unknown.
+ * @param {number} [chainId] - Chain id to look up; defaults to the active chain.
+ * @returns {ChainConfig | undefined} Chain configuration.
+ */
+export function getChainConfig(chainId?: number): ChainConfig | undefined {
+  return CHAINS[chainId ?? DEFAULT_CHAIN_ID]
+}
+
+/**
+ * Display name of a network. The active chain honours NEXT_PUBLIC_NETWORK so a
+ * deployment can rename it without touching the registry.
+ * @param {number} [chainId] - Chain id; defaults to the active chain.
+ * @returns {string} Network name, or a generic label for unknown chains.
+ */
+export function getChainName(chainId?: number): string {
+  if (isActiveChain(chainId)) return NETWORK_NAME
+  return getChainConfig(chainId)?.name || `Chain ${chainId}`
+}
+
+/**
+ * Block explorer base URL for a chain, environment value first for the active one.
+ * @param {number} [chainId] - Chain id; defaults to the active chain.
+ * @returns {string} Explorer base URL without trailing slash.
+ */
+export function getExplorerUrl(chainId?: number): string {
+  if (isActiveChain(chainId)) return stripTrailingSlash(EXPLORER_L2_URL)
+  return stripTrailingSlash(getChainConfig(chainId)?.explorerUrl || EXPLORER_L2_URL)
+}
+
+/**
+ * Explorer base URL used for NFT mint transactions.
+ * @param {number} [chainId] - Chain id; defaults to the active chain.
+ * @returns {string} Explorer base URL without trailing slash.
+ */
+export function getNftExplorerUrl(chainId?: number): string {
+  if (isActiveChain(chainId)) return stripTrailingSlash(EXPLORER_NFT_URL)
+  return stripTrailingSlash(getChainConfig(chainId)?.nftExplorerUrl || EXPLORER_NFT_URL)
+}
+
+/**
+ * NFT marketplace collection base URL for a chain.
+ * @param {number} [chainId] - Chain id; defaults to the active chain.
+ * @returns {string} Marketplace base URL without trailing slash.
+ */
+export function getNftMarketplaceUrl(chainId?: number): string {
+  if (isActiveChain(chainId)) return stripTrailingSlash(NFT_MARKETPLACE_URL)
+  return stripTrailingSlash(getChainConfig(chainId)?.nftMarketplaceUrl || NFT_MARKETPLACE_URL)
+}
+
+/**
+ * Absolute URL of the network icon, or an empty string when the chain has none.
+ * @param {number} [chainId] - Chain id; defaults to the active chain.
+ * @returns {string} Icon URL, or '' when there is no artwork for the chain.
+ */
+export function getChainLogoUrl(chainId?: number): string {
+  const logo = getChainConfig(chainId)?.logo
+  return logo ? `${GCP_BUCKET_BASE_URL}/${logo}` : ''
+}

--- a/src/config-chains.ts
+++ b/src/config-chains.ts
@@ -37,6 +37,13 @@ export type ChainConfig = {
    * artwork uploaded for the chain — callers fall back to a text avatar.
    */
   logo: string
+  /**
+   * Network identifier used by Layerswap as the deposit destination, taken from
+   * their networks API. Empty when Layerswap does not list the chain: the
+   * deposit widget is then hidden, because sending a user to deposit on a
+   * network other than the one their wallet lives on would misroute the funds.
+   */
+  layerswapNetwork: string
   testnet: boolean
 }
 
@@ -57,6 +64,7 @@ export const CHAINS: Record<number, ChainConfig> = {
     nftExplorerUrl: 'https://scrollscan.com',
     nftMarketplaceUrl: 'https://opensea.io/assets/scroll',
     logo: '',
+    layerswapNetwork: 'SCROLL_MAINNET',
     testnet: false
   },
   [SCROLL_SEPOLIA_CHAIN_ID]: {
@@ -66,6 +74,8 @@ export const CHAINS: Record<number, ChainConfig> = {
     nftExplorerUrl: 'https://sepolia.scrollscan.com',
     nftMarketplaceUrl: 'https://testnets.opensea.io/assets/scroll-sepolia',
     logo: '',
+    // Layerswap lists no testnets in its public networks API.
+    layerswapNetwork: '',
     testnet: true
   },
   [ARBITRUM_CHAIN_ID]: {
@@ -75,6 +85,7 @@ export const CHAINS: Record<number, ChainConfig> = {
     nftExplorerUrl: 'https://arbiscan.io',
     nftMarketplaceUrl: 'https://opensea.io/assets/arbitrum',
     logo: '',
+    layerswapNetwork: 'ARBITRUM_MAINNET',
     testnet: false
   },
   [ARBITRUM_SEPOLIA_CHAIN_ID]: {
@@ -84,6 +95,8 @@ export const CHAINS: Record<number, ChainConfig> = {
     nftExplorerUrl: 'https://sepolia.arbiscan.io',
     nftMarketplaceUrl: 'https://testnets.opensea.io/assets/arbitrum_sepolia',
     logo: '',
+    // Pending: confirm the sandbox identifier with Layerswap to re-enable deposits in dev.
+    layerswapNetwork: '',
     testnet: true
   },
   [POLYGON_CHAIN_ID]: {
@@ -93,6 +106,7 @@ export const CHAINS: Record<number, ChainConfig> = {
     nftExplorerUrl: 'https://polygonscan.com',
     nftMarketplaceUrl: 'https://opensea.io/assets/matic',
     logo: '',
+    layerswapNetwork: 'POLYGON_MAINNET',
     testnet: false
   }
 }
@@ -159,4 +173,21 @@ export function getNftMarketplaceUrl(chainId?: number): string {
 export function getChainLogoUrl(chainId?: number): string {
   const logo = getChainConfig(chainId)?.logo
   return logo ? `${GCP_BUCKET_BASE_URL}/${logo}` : ''
+}
+
+/**
+ * Layerswap destination network for a chain, or '' when Layerswap has none.
+ *
+ * A deposit lands on the network Layerswap is told to send it to, at the
+ * address it is given. Those two have to belong to the same chain: a user's
+ * ChatterPay address is a per-chain proxy, so the same address on another
+ * network is not theirs. That is why this follows the active chain rather than
+ * being fixed, and why callers must treat '' as "no deposit flow available"
+ * instead of falling back to some other network.
+ *
+ * @param {number} [chainId] - Chain id; defaults to the active chain.
+ * @returns {string} Layerswap network identifier, or '' when unsupported.
+ */
+export function getLayerswapNetwork(chainId?: number): string {
+  return getChainConfig(chainId)?.layerswapNetwork || ''
 }

--- a/src/locales/langs/br.json
+++ b/src/locales/langs/br.json
@@ -464,7 +464,7 @@
     "network-warning": "Qualquer ativo enviado em outra rede será perdido",
     "wallet-address": "Endereço da carteira",
     "copy-address": "Copiar endereço",
-    "show-address": "Ver meu endereço na Scroll",
+    "show-address": "Ver meu endereço na {network}",
     "back-to-deposit": "Voltar ao depósito"
   },
   "withdraw": {

--- a/src/locales/langs/br.json
+++ b/src/locales/langs/br.json
@@ -1069,7 +1069,9 @@
     "errors": {
       "title": "Solicitação inválida",
       "missingAddress": "Um endereço de carteira é necessário. Forneça seu endereço na URL (?address=0x...).",
-      "invalidAddress": "O endereço de carteira fornecido não é um endereço Ethereum válido."
+      "invalidAddress": "O endereço de carteira fornecido não é um endereço Ethereum válido.",
+      "unsupportedNetworkTitle": "Depósitos indisponíveis nesta rede",
+      "unsupportedNetwork": "Os depósitos externos ainda não estão disponíveis na rede {network}. Você ainda pode depositar enviando fundos diretamente para o endereço da sua carteira."
     }
   },
   "b2b": {

--- a/src/locales/langs/en.json
+++ b/src/locales/langs/en.json
@@ -1069,7 +1069,9 @@
     "errors": {
       "title": "Invalid Request",
       "missingAddress": "A wallet address is required. Please provide your address in the URL (?address=0x...).",
-      "invalidAddress": "The wallet address provided is not a valid Ethereum address."
+      "invalidAddress": "The wallet address provided is not a valid Ethereum address.",
+      "unsupportedNetworkTitle": "Deposits not available on this network",
+      "unsupportedNetwork": "External deposits are not available on {network} yet. You can still deposit by sending funds directly to your wallet address."
     }
   },
   "b2b": {

--- a/src/locales/langs/en.json
+++ b/src/locales/langs/en.json
@@ -464,7 +464,7 @@
     "network-warning": "Any asset sent in other network will be lost",
     "wallet-address": "Wallet Address",
     "copy-address": "Copy Address",
-    "show-address": "See my address on Scroll",
+    "show-address": "See my address on {network}",
     "back-to-deposit": "Back to deposit"
   },
   "withdraw": {

--- a/src/locales/langs/es.json
+++ b/src/locales/langs/es.json
@@ -1069,7 +1069,9 @@
     "errors": {
       "title": "Solicitud inválida",
       "missingAddress": "Se requiere una dirección de billetera. Proporciónala en la URL (?address=0x...).",
-      "invalidAddress": "La dirección de billetera proporcionada no es una dirección Ethereum válida."
+      "invalidAddress": "La dirección de billetera proporcionada no es una dirección Ethereum válida.",
+      "unsupportedNetworkTitle": "Depósitos no disponibles en esta red",
+      "unsupportedNetwork": "Los depósitos externos todavía no están disponibles en {network}. Igual podés depositar enviando fondos directamente a la dirección de tu billetera."
     }
   },
   "b2b": {

--- a/src/locales/langs/es.json
+++ b/src/locales/langs/es.json
@@ -464,7 +464,7 @@
     "network-warning": "Cualquier activo enviado en otra red se perderá",
     "wallet-address": "Dirección de billetera",
     "copy-address": "Copiar dirección",
-    "show-address": "Ver mi dirección en Scroll",
+    "show-address": "Ver mi dirección en {network}",
     "back-to-deposit": "Volver a depositar"
   },
   "withdraw": {

--- a/src/sections/account/profile-detail.tsx
+++ b/src/sections/account/profile-detail.tsx
@@ -14,6 +14,10 @@ import { useTranslate } from 'src/locales'
 import { useAuthContext } from 'src/auth/hooks'
 import { useSnackbar } from 'src/components/snackbar'
 import Iconify from 'src/components/iconify'
+import { DEFAULT_CHAIN_ID } from 'src/config-global'
+import { getChainName } from 'src/config-chains'
+
+import type { IAccountWallet } from 'src/types/account'
 
 // ----------------------------------------------------------------------
 
@@ -46,7 +50,7 @@ function RowIcon({ icon }: { icon: string }) {
 }
 
 /**
- * Profile details list: name, phone, wallet (copyable) and email.
+ * Profile details list: name, phone, wallets (one per network, copyable) and email.
  * @returns {JSX.Element} Profile detail card.
  */
 export default function ProfileDetail() {
@@ -54,6 +58,31 @@ export default function ProfileDetail() {
   const theme = useTheme()
   const { user } = useAuthContext()
   const { enqueueSnackbar } = useSnackbar()
+
+  const handleCopy = async (address: string) => {
+    try {
+      await navigator.clipboard.writeText(address)
+      enqueueSnackbar(t('common.copied'))
+    } catch {
+      enqueueSnackbar(t('common.msg.update-error'), { variant: 'error' })
+    }
+  }
+
+  // A user owns one wallet per network they have operated on. The list comes
+  // from the API already ordered with the active network first; fall back to the
+  // single active wallet for sessions created before wallets travelled in the payload.
+  const wallets: IAccountWallet[] =
+    Array.isArray(user?.wallets) && user.wallets.length
+      ? user.wallets
+      : user?.wallet
+        ? [
+            {
+              wallet_proxy: user.wallet,
+              wallet_eoa: user.walletEOA || '',
+              chain_id: DEFAULT_CHAIN_ID
+            }
+          ]
+        : []
 
   return (
     <Card
@@ -85,31 +114,34 @@ export default function ProfileDetail() {
             />
           </ListItem>
 
-          <ListItem sx={rowSx}>
-            <RowIcon icon='solar:wallet-bold-duotone' />
-            <ListItemText
-              primary={t('user.profile.rows.wallet')}
-              secondary={user?.wallet || t('common.nodata')}
-              secondaryTypographyProps={{ sx: { wordBreak: 'break-all' } }}
-            />
-            {!!(user?.wallet || '').trim() && (
-              <IconButton
-                size='small'
-                onClick={async () => {
-                  try {
-                    await navigator.clipboard.writeText(user!.wallet)
-                    enqueueSnackbar(t('common.copied'))
-                  } catch {
-                    enqueueSnackbar(t('common.msg.update-error'), { variant: 'error' })
-                  }
-                }}
-                aria-label={t('common.accessibility.copy-wallet')}
-                sx={{ ml: 1 }}
-              >
-                <Iconify icon='eva:copy-fill' width={18} />
-              </IconButton>
-            )}
-          </ListItem>
+          {wallets.length === 0 ? (
+            <ListItem sx={rowSx}>
+              <RowIcon icon='solar:wallet-bold-duotone' />
+              <ListItemText
+                primary={t('user.profile.rows.wallet')}
+                secondary={t('common.nodata')}
+              />
+            </ListItem>
+          ) : (
+            wallets.map((w) => (
+              <ListItem key={`${w.chain_id}-${w.wallet_proxy}`} sx={rowSx}>
+                <RowIcon icon='solar:wallet-bold-duotone' />
+                <ListItemText
+                  primary={`${t('user.profile.rows.wallet')} · ${getChainName(w.chain_id)}`}
+                  secondary={w.wallet_proxy}
+                  secondaryTypographyProps={{ sx: { wordBreak: 'break-all' } }}
+                />
+                <IconButton
+                  size='small'
+                  onClick={() => handleCopy(w.wallet_proxy)}
+                  aria-label={t('common.accessibility.copy-wallet')}
+                  sx={{ ml: 1 }}
+                >
+                  <Iconify icon='eva:copy-fill' width={18} />
+                </IconButton>
+              </ListItem>
+            ))
+          )}
 
           <ListItemButton sx={rowSx} component={RouterLink} href={paths.dashboard.user.email}>
             <RowIcon icon='solar:letter-bold-duotone' />

--- a/src/sections/banking/banking-recent-transitions-row.tsx
+++ b/src/sections/banking/banking-recent-transitions-row.tsx
@@ -13,7 +13,8 @@ import { useSnackbar } from 'src/components/snackbar'
 import { fDate, fTime } from 'src/utils/format-time'
 
 import { useTranslate } from 'src/locales'
-import { EXPLORER_L2_URL } from 'src/config-global'
+import { EXPLORER_L2_URL, DEFAULT_CHAIN_ID } from 'src/config-global'
+import { getChainName, getExplorerUrl } from 'src/config-chains'
 
 import { HugeiconsIcon } from '@hugeicons/react'
 import {
@@ -32,6 +33,7 @@ import {
   isPolymarketTrx,
   getPolymarketSide,
   getContactData,
+  isIncomingTrx,
   formatMarketSlug,
   formatStepName
 } from './banking-transaction-helpers'
@@ -42,9 +44,6 @@ import type { RowBadge } from './banking-transaction-row-parts'
 import type { ITransaction } from 'src/types/wallet'
 
 // ----------------------------------------------------------------------
-
-const POLYGON_EXPLORER_URL = 'https://polygonscan.com'
-const POLYGON_CHAIN_ID = 137
 
 function getRowBadge(
   polymarketSide: PolymarketSide | null,
@@ -92,7 +91,8 @@ function getRowBadge(
 }
 
 type Props = {
-  userWallet: string
+  /** Every wallet of the user — the history spans all the networks they used. */
+  userWallets: string[]
   row: ITransaction
   mdUp: boolean
   hideValues: boolean
@@ -106,17 +106,21 @@ type Props = {
  * @returns {JSX.Element} The table row.
  */
 export default function BankingRecentTransitionsRow({
-  userWallet,
+  userWallets,
   row,
   mdUp,
   hideValues,
   tokenLogos
 }: Props) {
   const { t } = useTranslate()
-  const trxReceive: boolean = userWallet === row.wallet_to
+  const trxReceive: boolean = isIncomingTrx(userWallets, row)
   const isPolymarket = isPolymarketTrx(row.type)
   const polymarketSide = isPolymarket ? getPolymarketSide(row) : null
-  const { contactName, contactIdentifier, calculatedAmount } = getContactData(userWallet, row, mdUp)
+  const { contactName, contactIdentifier, calculatedAmount } = getContactData(
+    userWallets,
+    row,
+    mdUp
+  )
 
   const { enqueueSnackbar } = useSnackbar()
   const { copy } = useCopyToClipboard()
@@ -170,11 +174,23 @@ export default function BankingRecentTransitionsRow({
   const isRealHash =
     (bridgeTxHash && bridgeTxHash.startsWith('0x')) ||
     (row.trx_hash && row.trx_hash.startsWith('0x'))
-  const explorerBase = row.chain_id === POLYGON_CHAIN_ID ? POLYGON_EXPLORER_URL : EXPLORER_L2_URL
+  // The history spans every network the user operated on, so the explorer comes
+  // from the row's own chain — Polygon for Polymarket rows, the home chain of
+  // that record otherwise. The bridge hash is always on the active home chain.
+  const explorerBase = getExplorerUrl(row.chain_id)
   const trxLink =
     bridgeTxHash && bridgeTxHash.startsWith('0x')
       ? `${EXPLORER_L2_URL}/tx/${bridgeTxHash}`
       : `${explorerBase}/tx/${row.trx_hash}`
+
+  // Only labelled when the row doesn't belong to the active network, so the
+  // common case stays uncluttered.
+  // Polymarket rows are already labelled as such and always live on Polygon, so
+  // tagging them with the network again would be noise.
+  const foreignChainLabel =
+    !isPolymarket && row.chain_id != null && row.chain_id !== DEFAULT_CHAIN_ID
+      ? getChainName(row.chain_id)
+      : null
 
   // Live step label for optimistic (in-flight) records.
   const pendingStepLabel = row.polymarket_pending_step
@@ -307,6 +323,11 @@ export default function BankingRecentTransitionsRow({
         <Typography variant='caption' sx={{ color: 'text.secondary', display: 'block', mt: 0.5 }}>
           {fTime(new Date(row.date))}
         </Typography>
+        {foreignChainLabel && (
+          <Typography variant='caption' sx={{ color: 'text.disabled', display: 'block' }}>
+            {foreignChainLabel}
+          </Typography>
+        )}
       </TableCell>
 
       <TableCell align='right' sx={{ py: 2, pr: 3 }}>
@@ -339,6 +360,7 @@ export default function BankingRecentTransitionsRow({
               )}
               <Box component='span' sx={{ display: 'block', mt: 0.5 }}>
                 {`${fDate(new Date(row.date))} ${fTime(new Date(row.date))}`}
+                {foreignChainLabel ? ` · ${foreignChainLabel}` : ''}
               </Box>
             </>
           }

--- a/src/sections/banking/banking-recent-transitions.tsx
+++ b/src/sections/banking/banking-recent-transitions.tsx
@@ -40,7 +40,8 @@ interface Props extends CardProps {
   isLoading: boolean
   tableData: ITransaction[]
   tableLabels: any
-  userWallet: string
+  /** Every wallet of the user — the history spans all the networks they used. */
+  userWallets: string[]
   tokenLogos?: Record<string, string>
   hideValues?: boolean
 }
@@ -51,7 +52,7 @@ export default function BankingRecentTransitions({
   tableLabels,
   isLoading,
   tableData,
-  userWallet,
+  userWallets,
   tokenLogos = EMPTY_TOKEN_LOGOS,
   hideValues = false,
   ...other
@@ -87,7 +88,7 @@ export default function BankingRecentTransitions({
               visibleData.map((row) => (
                 <BankingRecentTransitionsRow
                   key={row.id}
-                  userWallet={userWallet}
+                  userWallets={userWallets}
                   row={row}
                   mdUp={mdUp}
                   hideValues={hideValues}

--- a/src/sections/banking/banking-transaction-helpers.ts
+++ b/src/sections/banking/banking-transaction-helpers.ts
@@ -41,14 +41,26 @@ export function getPolymarketSide(data: ITransaction): PolymarketSide {
 }
 
 /**
+ * Whether a transaction is incoming for the user.
+ * The history aggregates every network the user operated on, and each network
+ * has its own wallet address, so the check is against the whole set.
+ * @param {string[]} userWallets - Every wallet address of the user.
+ * @param {ITransaction} data - Transaction record.
+ * @returns {boolean} True when the user is the receiving side.
+ */
+export function isIncomingTrx(userWallets: string[], data: ITransaction): boolean {
+  return !!data.wallet_to && userWallets.includes(data.wallet_to)
+}
+
+/**
  * Derive the counterparty display data and formatted amount for a row.
- * @param {string} userWallet - Current user's wallet address.
+ * @param {string[]} userWallets - Every wallet address of the user (one per network).
  * @param {ITransaction} data - Transaction record.
  * @param {boolean} mdUp - Desktop breakpoint flag (contact name hidden on mobile).
  * @returns {object} `contactName`, `contactIdentifier` and `calculatedAmount`.
  */
 export function getContactData(
-  userWallet: string,
+  userWallets: string[],
   data: ITransaction,
   mdUp: boolean
 ): { contactName: string; contactIdentifier: string; calculatedAmount: string } {
@@ -56,7 +68,7 @@ export function getContactData(
   let contactIdentifier: string = ''
   let calculatedAmount: string = ''
 
-  const trxReceive: boolean = userWallet === data.wallet_to
+  const trxReceive: boolean = isIncomingTrx(userWallets, data)
 
   if (isPolymarketTrx(data.type)) {
     contactIdentifier = ''

--- a/src/sections/banking/dashboard-deposit-modal.tsx
+++ b/src/sections/banking/dashboard-deposit-modal.tsx
@@ -9,6 +9,7 @@ import {
   Box,
   Stack,
   Alert,
+  Avatar,
   Button,
   Dialog,
   Typography,
@@ -22,7 +23,7 @@ import { Copy01Icon, QrCode01Icon } from '@hugeicons/core-free-icons'
 
 import { useTranslate } from 'src/locales'
 import Iconify from 'src/components/iconify'
-import { GCP_BUCKET_BASE_URL } from 'src/config-global'
+import { getChainName, getChainLogoUrl } from 'src/config-chains'
 
 import LayerswapWidget from 'src/sections/deposit/view/layerswap-widget'
 
@@ -39,11 +40,15 @@ const transition = { duration: 0.1, ease: 'easeOut' as const }
 /**
  * Deposit modal with two views:
  * - Main: multichain deposit via Layerswap (primary CTA)
- * - Address: wallet address + QR on Scroll network (secondary)
+ * - Address: wallet address + QR on the active network (secondary)
  */
 export default function DashboardDepositModal({ open, onClose, walletAddress }: Props) {
   const { t } = useTranslate()
   const [showAddress, setShowAddress] = useState(false)
+
+  // Deposits by address land on the network the app operates on, whichever it is.
+  const networkName = getChainName()
+  const networkLogo = getChainLogoUrl()
 
   const handleClose = () => {
     onClose()
@@ -89,7 +94,10 @@ export default function DashboardDepositModal({ open, onClose, walletAddress }: 
                     startIcon={<HugeiconsIcon icon={QrCode01Icon} size={18} />}
                     sx={{ mt: 0.5, mb: 3 }}
                   >
-                    {t('deposit.show-address', 'See my address on Scroll')}
+                    {t('deposit.show-address', 'See my address on {network}').replace(
+                      '{network}',
+                      networkName
+                    )}
                   </Button>
                 </Box>
               </Stack>
@@ -130,16 +138,19 @@ export default function DashboardDepositModal({ open, onClose, walletAddress }: 
                     borderRadius: 1.5
                   }}
                 >
-                  <Box
-                    component='img'
-                    src={`${GCP_BUCKET_BASE_URL}/images/tokens/scr.svg`}
-                    alt='Scroll Network'
-                    loading='lazy'
-                    decoding='async'
-                    sx={{ width: 32, height: 32, borderRadius: '50%' }}
-                  />
+                  {/* Not every network has artwork uploaded, so fall back to the
+                      network initial instead of rendering a broken image. */}
+                  <Avatar
+                    src={networkLogo || undefined}
+                    alt={networkName}
+                    sx={{ width: 32, height: 32, bgcolor: 'primary.main', fontSize: 14 }}
+                  >
+                    {networkName.charAt(0).toUpperCase()}
+                  </Avatar>
                   <Stack spacing={0.25}>
-                    <Typography variant='subtitle2'>{t('deposit.network')}: Scroll</Typography>
+                    <Typography variant='subtitle2'>
+                      {t('deposit.network')}: {networkName}
+                    </Typography>
                   </Stack>
                 </Stack>
 

--- a/src/sections/banking/dashboard-deposit-modal.tsx
+++ b/src/sections/banking/dashboard-deposit-modal.tsx
@@ -23,7 +23,7 @@ import { Copy01Icon, QrCode01Icon } from '@hugeicons/core-free-icons'
 
 import { useTranslate } from 'src/locales'
 import Iconify from 'src/components/iconify'
-import { getChainName, getChainLogoUrl } from 'src/config-chains'
+import { getChainName, getChainLogoUrl, getLayerswapNetwork } from 'src/config-chains'
 
 import LayerswapWidget from 'src/sections/deposit/view/layerswap-widget'
 
@@ -44,7 +44,12 @@ const transition = { duration: 0.1, ease: 'easeOut' as const }
  */
 export default function DashboardDepositModal({ open, onClose, walletAddress }: Props) {
   const { t } = useTranslate()
-  const [showAddress, setShowAddress] = useState(false)
+
+  // Layerswap cannot deposit into every network. Where it can't, the widget
+  // renders nothing, so the address view is the only way to deposit and the
+  // modal opens straight into it instead of on an empty first step.
+  const hasLayerswap = Boolean(getLayerswapNetwork())
+  const [showAddress, setShowAddress] = useState(!hasLayerswap)
 
   // Deposits by address land on the network the app operates on, whichever it is.
   const networkName = getChainName()
@@ -52,7 +57,7 @@ export default function DashboardDepositModal({ open, onClose, walletAddress }: 
 
   const handleClose = () => {
     onClose()
-    setShowAddress(false)
+    setShowAddress(!hasLayerswap)
   }
 
   const handleCopyAddress = () => {
@@ -169,18 +174,20 @@ export default function DashboardDepositModal({ open, onClose, walletAddress }: 
                   {t('deposit.copy-address')}
                 </Button>
 
-                <Button
-                  variant='text'
-                  size='small'
-                  startIcon={<Iconify icon='eva:arrow-back-fill' width={16} />}
-                  onClick={() => setShowAddress(false)}
-                  sx={{
-                    color: 'text.secondary',
-                    '&:hover': { color: 'text.primary' }
-                  }}
-                >
-                  {t('deposit.back-to-deposit', 'Back to deposit')}
-                </Button>
+                {hasLayerswap && (
+                  <Button
+                    variant='text'
+                    size='small'
+                    startIcon={<Iconify icon='eva:arrow-back-fill' width={16} />}
+                    onClick={() => setShowAddress(false)}
+                    sx={{
+                      color: 'text.secondary',
+                      '&:hover': { color: 'text.primary' }
+                    }}
+                  >
+                    {t('deposit.back-to-deposit', 'Back to deposit')}
+                  </Button>
+                )}
               </Stack>
             </m.div>
           )}

--- a/src/sections/banking/view/overview-banking-view.tsx
+++ b/src/sections/banking/view/overview-banking-view.tsx
@@ -98,6 +98,17 @@ function BankingDashboardContent() {
     }
   }, [user])
 
+  // Balances and every operation (deposit / withdraw / swap) stay on the active
+  // network's wallet. The history is the exception: it aggregates all of them, so
+  // the user doesn't lose sight of what they did on networks now retired.
+  const userWallets = useMemo<string[]>(() => {
+    const fromUser: string[] = Array.isArray(user?.wallets)
+      ? user.wallets.map((w: { wallet_proxy: string }) => w.wallet_proxy).filter(Boolean)
+      : []
+    if (fromUser.length) return fromUser
+    return walletAddress ? [walletAddress] : []
+  }, [user, walletAddress])
+
   useEffect(() => {
     if (!user?.id) return
     polymarketAccountStatus().then((res) => {
@@ -113,7 +124,9 @@ function BankingDashboardContent() {
   const {
     data: transactions,
     isLoading: isLoadingTrxs
-  }: { data: ITransaction[]; isLoading: boolean } = useGetWalletTransactionsCached(walletAddress)
+  }: { data: ITransaction[]; isLoading: boolean } = useGetWalletTransactionsCached(walletAddress, {
+    allChains: true
+  })
 
   const { pendingOps, addClaim, failOp, completeOp } = usePolymarketActivity()
 
@@ -262,7 +275,7 @@ function BankingDashboardContent() {
               { id: 'date', label: t('transactions.table-date') },
               { id: '' }
             ]}
-            userWallet={walletAddress || ''}
+            userWallets={userWallets}
             tokenLogos={tokenLogos}
             hideValues={hideValues}
           />

--- a/src/sections/deposit/view/deposit-view.tsx
+++ b/src/sections/deposit/view/deposit-view.tsx
@@ -14,6 +14,7 @@ import { alpha, useTheme } from '@mui/material/styles'
 import { paths } from 'src/routes/paths'
 import { useTranslate } from 'src/locales'
 import { CHATIZALO_PHONE_NUMBER } from 'src/config-global'
+import { getChainName, getLayerswapNetwork } from 'src/config-chains'
 
 import Iconify from 'src/components/iconify'
 
@@ -101,6 +102,17 @@ export default function DepositView() {
     )
   }
 
+  // Layerswap does not reach every network. Say so, instead of leaving the page
+  // blank where the widget would have been.
+  const renderUnsupportedNetwork = () => (
+    <Container maxWidth='sm' sx={{ py: { xs: 4, md: 6 } }}>
+      <Alert severity='info' sx={{ borderRadius: 2, boxShadow: theme.customShadows.z8 }}>
+        <AlertTitle>{t('layerswapDeposit.errors.unsupportedNetworkTitle')}</AlertTitle>
+        {t('layerswapDeposit.errors.unsupportedNetwork').replace('{network}', getChainName())}
+      </Alert>
+    </Container>
+  )
+
   // ----------------------------------------------------------------------
 
   return (
@@ -118,6 +130,7 @@ export default function DepositView() {
         {t('layerswapDeposit.title', 'Deposit to ChatterPay')}
       </Typography>
 
+      {!getLayerswapNetwork() && renderUnsupportedNetwork()}
       {isValid ? <LayerswapWidget destAddress={address} /> : renderError()}
 
       <Box sx={{ mt: 2, textAlign: 'center' }}>

--- a/src/sections/deposit/view/layerswap-widget.tsx
+++ b/src/sections/deposit/view/layerswap-widget.tsx
@@ -13,6 +13,7 @@ import { CoinsBitcoinIcon, LinkSquare02Icon } from '@hugeicons/core-free-icons'
 
 import { useTranslate } from 'src/locales'
 import { LAYERSWAP_BASE_URL } from 'src/config-global'
+import { getLayerswapNetwork } from 'src/config-chains'
 
 // ----------------------------------------------------------------------
 
@@ -35,16 +36,25 @@ type Props = {
 //
 // In development / testing environments LAYERSWAP_BASE_URL points at the
 // Layerswap sandbox so no real funds are involved.
+//
+// The destination network follows the active chain. It used to be fixed to
+// Scroll mainnet, which was correct only while that was the chain the app ran
+// on: destAddress is a per-chain proxy, so pairing it with a different network
+// tells the user to deposit at an address that is not theirs there. When
+// Layerswap does not support the active chain, the widget renders nothing
+// rather than offering a deposit that would be misrouted.
 // ----------------------------------------------------------------------
 
 export default function LayerswapWidget({ destAddress, plain = false }: Props) {
   const { t } = useTranslate()
   const theme = useTheme()
 
+  const destNetwork = getLayerswapNetwork()
+
   const layerswapUrl = useMemo(() => {
     const params = new URLSearchParams({
       // Destination config
-      to: 'SCROLL_MAINNET',
+      to: destNetwork,
       toAsset: 'USDT',
       fromAsset: 'USDT',
       destAddress,
@@ -64,9 +74,11 @@ export default function LayerswapWidget({ destAddress, plain = false }: Props) {
     })
 
     return `${LAYERSWAP_BASE_URL}?${params.toString()}`
-  }, [destAddress, t])
+  }, [destAddress, destNetwork, t])
 
   const isDark = theme.palette.mode === 'dark'
+
+  if (!destNetwork) return null
 
   return (
     <Box

--- a/src/sections/nfts/nft-item-claim.tsx
+++ b/src/sections/nfts/nft-item-claim.tsx
@@ -8,7 +8,8 @@ import { Card, Button, Typography } from '@mui/material'
 import { useResponsive } from 'src/hooks/use-responsive'
 
 import { useTranslate } from 'src/locales'
-import { BOT_WAPP_URL, NFT_MARKETPLACE_URL, NFT_IMAGE_REPOSITORY } from 'src/config-global'
+import { BOT_WAPP_URL, NFT_IMAGE_REPOSITORY } from 'src/config-global'
+import { getNftMarketplaceUrl } from 'src/config-chains'
 
 import { varFade } from 'src/components/animate'
 
@@ -26,7 +27,8 @@ export default function NftItemClaim({ nftId, nftData }: NftItemClaimProps) {
   const { t } = useTranslate()
 
   const handleOpenOpenSea = () => {
-    const url = `${NFT_MARKETPLACE_URL}/${nftData.minted_contract_address}/${nftId}`
+    // The NFT may have been minted on a network the app no longer operates on.
+    const url = `${getNftMarketplaceUrl(nftData.chain_id)}/${nftData.minted_contract_address}/${nftId}`
     window.open(url, '_blank')
   }
 

--- a/src/sections/nfts/nft-item-share.tsx
+++ b/src/sections/nfts/nft-item-share.tsx
@@ -20,7 +20,8 @@ import {
 import { useResponsive } from 'src/hooks/use-responsive'
 
 import { useTranslate } from 'src/locales'
-import { NFT_MARKETPLACE_URL, NFT_IMAGE_REPOSITORY } from 'src/config-global'
+import { NFT_IMAGE_REPOSITORY } from 'src/config-global'
+import { getNftMarketplaceUrl } from 'src/config-chains'
 
 import { varFade } from 'src/components/animate'
 
@@ -39,7 +40,8 @@ export default function NftItemShare({ nftId, nftData }: NftItemClaimProps) {
   const [openShare, setOpenShare] = useState(false)
   const { enqueueSnackbar } = useSnackbar()
 
-  const nftUrl = `${NFT_MARKETPLACE_URL}/${nftData.minted_contract_address}/${nftId}`
+  // A shared NFT may have been minted on a network the app no longer operates on.
+  const nftUrl = `${getNftMarketplaceUrl(nftData.chain_id)}/${nftData.minted_contract_address}/${nftId}`
 
   const handleOpenOpenSea = () => {
     window.open(nftUrl, '_blank')

--- a/src/sections/nfts/nft-item.tsx
+++ b/src/sections/nfts/nft-item.tsx
@@ -73,7 +73,9 @@ export default function NftItem({ nft }: Props) {
   const linkTrx = `${getNftExplorerUrl(chainId)}/tx/${trxId}`
   const linkMarketplace = `${getNftMarketplaceUrl(chainId)}/${nft.minted_contract_address}/${nftId}`
 
-  const mintUrl = `${UI_BASE_URL}/nfts/mint/${nftId.toString()}`
+  // Token ids repeat across networks, so a shared link has to name the network
+  // its NFT belongs to; without it the link resolves against the active one.
+  const mintUrl = `${UI_BASE_URL}/nfts/mint/${nftId.toString()}${isForeignChain ? `?chainId=${chainId}` : ''}`
   const linkShare = `${NFT_SHARE.replace('MESSAGE', `${t('nfts.mint')}: ${mintUrl}`)}`
 
   const [openMetadata, setOpenMetadata] = useState(false)

--- a/src/sections/nfts/nft-item.tsx
+++ b/src/sections/nfts/nft-item.tsx
@@ -16,7 +16,8 @@ import { alpha, useTheme } from '@mui/material/styles'
 
 import { useTranslate } from 'src/locales'
 import { fDate } from 'src/utils/format-time'
-import { NFT_SHARE, UI_BASE_URL, EXPLORER_NFT_URL, NFT_MARKETPLACE_URL } from 'src/config-global'
+import { NFT_SHARE, UI_BASE_URL, DEFAULT_CHAIN_ID } from 'src/config-global'
+import { getChainName, getNftExplorerUrl, getNftMarketplaceUrl } from 'src/config-chains'
 
 import Iconify from 'src/components/iconify'
 import CustomPopover, { usePopover } from 'src/components/custom-popover'
@@ -64,8 +65,13 @@ export default function NftItem({ nft }: Props) {
 
   const { trxId, nftId, metadata } = nft
 
-  const linkTrx = `${EXPLORER_NFT_URL}/tx/${trxId}`
-  const linkMarketplace = `${NFT_MARKETPLACE_URL}/${nft.minted_contract_address}/${nftId}`
+  // The gallery mixes networks, so explorer and marketplace follow the chain the
+  // NFT was minted on rather than the one the app is currently operating on.
+  const chainId = nft.chain_id
+  const isForeignChain = chainId != null && chainId !== DEFAULT_CHAIN_ID
+
+  const linkTrx = `${getNftExplorerUrl(chainId)}/tx/${trxId}`
+  const linkMarketplace = `${getNftMarketplaceUrl(chainId)}/${nft.minted_contract_address}/${nftId}`
 
   const mintUrl = `${UI_BASE_URL}/nfts/mint/${nftId.toString()}`
   const linkShare = `${NFT_SHARE.replace('MESSAGE', `${t('nfts.mint')}: ${mintUrl}`)}`
@@ -194,6 +200,14 @@ export default function NftItem({ nft }: Props) {
           <Box sx={{ position: 'absolute', top: 12, right: 12, ...overlayChipSx }}>
             {editionLabel}
           </Box>
+
+          {/* Only flagged when it isn't the active network — otherwise every card
+              would carry the same redundant label. */}
+          {isForeignChain && (
+            <Box sx={{ position: 'absolute', bottom: 12, left: 12, ...overlayChipSx }}>
+              {getChainName(chainId)}
+            </Box>
+          )}
 
           <Link href={linkMarketplace} target='_blank' rel='noopener' underline='none'>
             <Box

--- a/src/sections/nfts/view/nft-mint-view.tsx
+++ b/src/sections/nfts/view/nft-mint-view.tsx
@@ -17,8 +17,9 @@ import NftItemClaim from '../nft-item-claim'
 
 type NftItemProps = {
   nftId: string
+  chainId?: number
 }
-export default function NftMintView({ nftId }: NftItemProps) {
+export default function NftMintView({ nftId, chainId }: NftItemProps) {
   const { t } = useTranslate()
   const settings = useSettingsContext()
 
@@ -28,7 +29,7 @@ export default function NftMintView({ nftId }: NftItemProps) {
   }: {
     data: INFT
     isLoading: boolean
-  } = useGetNftById(nftId)
+  } = useGetNftById(nftId, chainId)
 
   const notFound = !nftData
 

--- a/src/sections/nfts/view/nft-share-view.tsx
+++ b/src/sections/nfts/view/nft-share-view.tsx
@@ -17,8 +17,9 @@ import NftItemShare from '../nft-item-share'
 
 type NftItemProps = {
   nftId: string
+  chainId?: number
 }
-export default function NftShareView({ nftId }: NftItemProps) {
+export default function NftShareView({ nftId, chainId }: NftItemProps) {
   const { t } = useTranslate()
   const settings = useSettingsContext()
 
@@ -28,7 +29,7 @@ export default function NftShareView({ nftId }: NftItemProps) {
   }: {
     data: INFT
     isLoading: boolean
-  } = useGetNftById(nftId)
+  } = useGetNftById(nftId, chainId)
 
   const notFound = !nftData
 

--- a/src/sections/nfts/view/nfts-view.tsx
+++ b/src/sections/nfts/view/nfts-view.tsx
@@ -44,8 +44,10 @@ export default function NftsView() {
     }
   }, [user])
 
+  // Read-only view: show the collection of every network the user ever minted on,
+  // not just the active one. Operating still targets the active network only.
   const { data: nfts, isLoading: loadingNfts }: { data: INFT[]; isLoading: boolean } =
-    useGetWalletNfts(walletAddress)
+    useGetWalletNfts(walletAddress, { allChains: true })
 
   const loading = !walletAddress || loadingNfts
   const safeNfts: INFT[] = loading ? [] : (nfts ?? [])

--- a/src/types/account.ts
+++ b/src/types/account.ts
@@ -9,14 +9,28 @@ export type UserSession = {
   ipHistory?: { ip: string; at: Date | string }[]
 }
 
+export type IAccountWallet = {
+  wallet_proxy: string
+  wallet_eoa: string
+  chain_id: number
+  status?: string
+}
+
 export type IAccount = {
   id: string
   name: string
   email?: string
   phone_number: string
   photo: string
+  /** Proxy wallet of the active chain (see DEFAULT_CHAIN_ID). */
   wallet: string
+  /** EOA of the active chain's wallet. */
   walletEOA: string
+  /**
+   * Every wallet the user owns, one per chain they have operated on. Read paths
+   * always fill it in; the update DTOs don't carry it, hence optional.
+   */
+  wallets?: IAccountWallet[]
   code?: string
   front?: {
     sessions?: UserSession[]

--- a/src/types/jwt.ts
+++ b/src/types/jwt.ts
@@ -1,8 +1,16 @@
+import type { IAccountWallet } from './account'
+
 export type jwtPayloadUser = {
   id: string
   displayName: string
   wallet: string
   walletEOA: string
+  /**
+   * Every wallet of the user, one per chain. Display-only (profile, NFT and
+   * transaction history across networks) — deliberately kept out of the signed
+   * token, it is attached to the API response instead.
+   */
+  wallets?: IAccountWallet[]
   email: string
   photoURL: string
   phoneNumber: string

--- a/src/types/wallet.ts
+++ b/src/types/wallet.ts
@@ -56,6 +56,8 @@ export type INFT = {
   total_of_original?: number
   minted_contract_address: string
   metadata: INFTMetadata
+  /** Network the NFT was minted on. Absent on records written before it was tracked. */
+  chain_id?: number
 }
 
 export type ITransaction = {


### PR DESCRIPTION
## Changes related to #331

- Added a versioned per-network configuration file, indexed by network id, holding the display name, explorer, NFT explorer and marketplace of every network the app knows about. The active network still reads those values from its environment variables first, so deployments keep overriding them without a code change.
- Fixed the wallet the app picks for a user: it now takes the wallet of the network the app is operating on, instead of whichever network the user happened to use first. That wrong address was also being offered as the destination of the deposit flow.
- The profile page now lists every wallet the user owns, each labelled with its network and individually copyable, instead of a single one.
- The NFT gallery now shows the collection from every network the user has minted on, and each card links to the explorer and the marketplace of the network it was minted on. Cards from a network other than the active one are labelled with it. The public share and claim pages follow the same rule.
- The transaction history now aggregates the activity of every wallet the user owns into a single timeline, with each row linking to the explorer of its own network and labelled when it does not belong to the active one. The incoming/outgoing side of a transaction is now resolved against all of the user's wallets, which is what keeps rows from other networks from being displayed backwards.
- The deposit screen no longer names a fixed network: both the button and the network row now show the network actually in use.
- Replaced the deposit network icon, which pointed at an image that returns not-found, with one that falls back to the network initial when no artwork is available.
- Operating on funds — transfers, swaps, withdrawals and deposits — remains restricted to the single active network. Only the read-only views span networks.

## Related To

## Changes related to #333
- Fixed the page a certificate link opens: certificates are now looked up by identifier and network instead of identifier alone. Since every network numbers its certificates from zero, the same link was matching more than one certificate and returning the oldest.
- The network the app is operating on now wins that lookup, so anything just minted resolves correctly, and links created before the network changed still fall back to the certificate they were made for instead of breaking.
- Certificate links can now name their network explicitly, and the gallery adds it when sharing a certificate that belongs to a different network than the one in use.
- Fixed the query that fetches a single certificate for a wallet, which compared the identifier as a number while it is stored as text and therefore never returned anything.
- Fixed the query that resolves how many copies exist of an original, which could pick up the count of an unrelated certificate sharing its identifier on another network.
